### PR TITLE
AASA: match /countdown regardless of query (allow fragment-carried share-link payload)

### DIFF
--- a/site/public/apple-app-site-association.json
+++ b/site/public/apple-app-site-association.json
@@ -6,8 +6,7 @@
         "components": [
           {
             "/": "/countdown*",
-            "?": { "d": "*" },
-            "comment": "Shared single-countdown import links (matches /countdown and /countdown/)"
+            "comment": "Shared single-countdown import links. Matches /countdown (and /countdown/) regardless of query, so the payload can travel in the URL fragment (#...) instead of ?d= — the fragment survives link-preview/canonicalization stripping in transit."
           }
         ]
       }


### PR DESCRIPTION
Pairs with an upcoming Day Tracker app change (#97).

**Problem:** the share link puts the countdown payload in the query (`…/countdown?d=<long>`). When a link is sent to another person, the messaging transport / link-preview strips the long query, so the recipient's link arrives as bare `…/countdown?d=` and nothing imports.

**Fix (this PR):** drop the required `?d=*` matcher from the AASA so `/countdown` matches with any query **or none**. That lets the app move the payload into the URL **fragment** (`…/countdown#<data>`), which servers and link-previews never touch, so it survives in transit.

- Existing `?d=` links still match (no regression).
- Paired app change: generate + parse fragment links (kept backward-compatible with `?d=`).
- `site/dist/` is a build artifact regenerated from `site/public/` on deploy, so only `public/` is edited here.