### PR TITLE
Stamp real request URL into /countdown og:url (fixes iMessage share-link stripping)

### DIFF
--- a/site/Caddyfile
+++ b/site/Caddyfile
@@ -9,6 +9,15 @@
 	@aasa path /.well-known/apple-app-site-association /apple-app-site-association
 	rewrite @aasa /apple-app-site-association.json
 
+	# Shared-countdown links carry their payload in the ?d= query. Rich-link
+	# previewers (iMessage, etc.) replace the tappable URL with the page's
+	# og:url/canonical, so those MUST reflect the real incoming URL or the payload
+	# is stripped in transit. Render ONLY the /countdown page as a template so
+	# Caddy can stamp the live request URI ({{html .Req.RequestURI}}) into it.
+	# NOTE: keep Go-template syntax ({{ }}) out of the /countdown page's HTML.
+	@countdown path /countdown /countdown/
+	templates @countdown
+
 	file_server
 
 	handle_errors {

--- a/site/Dockerfile
+++ b/site/Dockerfile
@@ -18,3 +18,6 @@ FROM caddy:2-alpine AS runtime
 
 COPY site/Caddyfile /etc/caddy/Caddyfile
 COPY --from=build /workspace/site/dist/ /srv/
+# Fail the image build on a broken Caddyfile so a bad config can never take the
+# live site down on deploy.
+RUN caddy validate --adapter caddyfile --config /etc/caddy/Caddyfile

--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -8,6 +8,7 @@ type Props = {
   title?: string;
   description?: string;
   canonicalPath?: string;
+  canonicalOverride?: string;
   noindex?: boolean;
 };
 
@@ -15,10 +16,16 @@ const {
   title = "Sonnaz Group",
   description = "Sonnaz Group builds practical software for everyday tasks.",
   canonicalPath = "/",
+  canonicalOverride,
   noindex = false
 } = Astro.props;
 
-const canonicalUrl = new URL(canonicalPath, "https://sonnazgroup.com").toString();
+// When set, `canonicalOverride` is emitted verbatim as the canonical + og:url.
+// The shared-countdown page uses it to carry a Caddy template token so the live
+// server can stamp the real request URL (with the ?d= payload) into og:url —
+// see site/Caddyfile. Rich-link previewers (iMessage) adopt og:url as the
+// tappable link, so it must reflect the incoming URL or the payload is stripped.
+const canonicalUrl = canonicalOverride ?? new URL(canonicalPath, "https://sonnazgroup.com").toString();
 const deployEnvironment = (import.meta.env.PUBLIC_DEPLOY_ENV ?? "").toLowerCase();
 const isStaging = deployEnvironment === "staging";
 ---

--- a/site/src/pages/countdown.astro
+++ b/site/src/pages/countdown.astro
@@ -10,12 +10,19 @@ import { getAppBySlug } from "../data/apps";
 // Everyone else lands here, so point them at the App Store.
 const app = getAppBySlug("day-tracker");
 const appStore = app.downloads.find((download) => download.kind === "app-store");
+
+// og:url / canonical must reflect the REAL incoming URL (including the ?d=
+// payload) so rich-link previewers like iMessage keep the payload when they
+// adopt og:url as the tappable link. Caddy stamps the live request URI into this
+// token at serve time (see site/Caddyfile); `html` escapes it to prevent
+// reflected injection.
+const canonicalOverride = "https://sonnazgroup.com{{html .Req.RequestURI}}";
 ---
 
 <BaseLayout
   title={`Open shared countdown | ${app.name}`}
   description={`Someone shared a countdown with you. Get ${app.name} to open it on your iPhone.`}
-  canonicalPath="/countdown"
+  canonicalOverride={canonicalOverride}
   noindex={true}
 >
   <main style={`--app-accent: ${app.accent}`}>


### PR DESCRIPTION
Shared-countdown links (`…/countdown?d=<payload>`) open the app from Notes but were **stripped in iMessage**. iMessage builds a rich preview and adopts the page's `og:url`/canonical as the tappable link; the static site hardcoded `og:url` to the bare `https://sonnazgroup.com/countdown`, so the payload was dropped. A URL fragment can't fix it — the fragment never reaches the server, so it can't be echoed into `og:url`.

## Change
- **BaseLayout.astro:** new optional `canonicalOverride` prop, emitted verbatim as `<link rel="canonical">` + `<meta property="og:url">`.
- **countdown.astro:** sets `canonicalOverride` to a Caddy template token so the live server stamps the real request URL into `og:url`.
- **Caddyfile:** `templates` scoped to `/countdown` **only**; Caddy replaces `{{html .Req.RequestURI}}` with the HTML-escaped live request URI (path + query), so `og:url` reflects the incoming URL including `?d=`. No other page is templated.
- **Dockerfile:** `caddy validate` after copying config + dist, so a broken Caddyfile fails the image build (and CI) instead of taking the live site down on deploy.

## Verification
- `npm run build` confirmed the token lands verbatim in `dist/countdown/index.html`; no other built page contains `{{`.
- Adversarial review (5 agents): security **clean** (the `html`-escaped reflection is XSS-safe — no attribute breakout); a reviewer ran the real `caddy:2-alpine` image with this exact Caddyfile + dist and confirmed the og:url stamping works and the site serves normally (the only quirk, a harmless 308 `/countdown`→`/countdown/`, the app already tolerates).

Paired with the app change (payload moved from fragment back to `?d=` query). Non-breaking for existing links.